### PR TITLE
Upgrade to rustls 0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.4"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967d6dd42f16dbf0eb8040cb9e477933562684d3918f7d253f2ff9087fb3e7a3"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rustls",
+ "rustls 0.22.2",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -1234,6 +1234,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e56521f047352df0db9a3c5aafc573eeb8909ab80f9d4cba201d8d73539009"
+dependencies = [
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,7 +1309,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls",
+ "rustls 0.23.0",
  "rustls-pki-types",
  "rustls-webpki",
  "sec1",
@@ -1609,7 +1623,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls",
+ "rustls 0.22.2",
  "rustls-pki-types",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ pkcs8 = { version = "0.10.2", features = ["pem", "pkcs5"] }
 pki-types = { package = "rustls-pki-types", version = "1.0.1", default-features = false }
 rand_core = "0.6.4"
 rsa = { version = "0.9.2", features = ["sha2"] }
-rustls = { version = "0.22.1", default-features = false }
+rustls = { version = "0.23.0", default-features = false }
 sec1 = { version = "0.7.3", features = ["pkcs8", "pem"] }
 sha2 = "0.10.7"
 signature = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ webpki = { package = "rustls-webpki", version = "0.102.0", default-features = fa
 x25519-dalek = "2"
 
 [features]
-default = ["std"]
+default = ["std", "tls12"]
 logging = ["rustls/logging"]
 tls12 = ["rustls/tls12"]
-std = ["webpki/std", "pki-types/std"]
+std = ["webpki/std", "pki-types/std", "rustls/std"]
 alloc = ["webpki/alloc", "pki-types/alloc"]
 
 [dev-dependencies]

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -1,2 +1,54 @@
+use aead::Buffer;
+use rustls::crypto::cipher::{BorrowedPayload, PrefixedPayload};
+
 pub mod chacha20;
 pub mod gcm;
+
+pub(crate) struct EncryptBufferAdapter<'a>(&'a mut PrefixedPayload);
+
+impl AsRef<[u8]> for EncryptBufferAdapter<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for EncryptBufferAdapter<'_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
+impl Buffer for EncryptBufferAdapter<'_> {
+    fn extend_from_slice(&mut self, other: &[u8]) -> aead::Result<()> {
+        self.0.extend_from_slice(other);
+        Ok(())
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len)
+    }
+}
+
+pub(crate) struct DecryptBufferAdapter<'a, 'p>(&'a mut BorrowedPayload<'p>);
+
+impl AsRef<[u8]> for DecryptBufferAdapter<'_, '_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+impl AsMut<[u8]> for DecryptBufferAdapter<'_, '_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0
+    }
+}
+
+impl Buffer for DecryptBufferAdapter<'_, '_> {
+    fn extend_from_slice(&mut self, _: &[u8]) -> aead::Result<()> {
+        unreachable!("not used by `AeadInPlace::decrypt_in_place`")
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len)
+    }
+}

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,8 +1,9 @@
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 
 use digest::{Digest, OutputSizeUser};
 use paste::paste;
-use rustls::{crypto, crypto::hash};
+use rustls::crypto::{self, hash};
 use sha2::{Sha256, Sha384};
 
 macro_rules! impl_hash {

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 
 use crypto_common::OutputSizeUser;

--- a/src/kx.rs
+++ b/src/kx.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 
 use crypto::{SharedSecret, SupportedKxGroup};
@@ -29,8 +30,11 @@ impl crypto::ActiveKeyExchange for X25519KeyExchange {
         let peer_array: [u8; 32] = peer
             .try_into()
             .map_err(|_| rustls::Error::from(rustls::PeerMisbehaved::InvalidKeyShare))?;
-        let their_pub = x25519_dalek::PublicKey::from(peer_array);
-        Ok(self.priv_key.diffie_hellman(&their_pub).as_ref().into())
+        Ok(self
+            .priv_key
+            .diffie_hellman(&peer_array.into())
+            .as_ref()
+            .into())
     }
 
     fn pub_key(&self) -> &[u8] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,17 +5,19 @@
     clippy::std_instead_of_alloc,
     clippy::std_instead_of_core
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 
 use alloc::sync::Arc;
 
+use rustls::crypto::{
+    CipherSuiteCommon, CryptoProvider, GetRandomFailed, KeyProvider, SecureRandom,
+};
+use rustls::{CipherSuite, SupportedCipherSuite, Tls13CipherSuite};
+
 #[cfg(feature = "tls12")]
 use rustls::SignatureScheme;
-use rustls::{
-    crypto::{CipherSuiteCommon, CryptoProvider, GetRandomFailed, KeyProvider, SecureRandom},
-    CipherSuite, SupportedCipherSuite, Tls13CipherSuite,
-};
 
 #[derive(Debug)]
 pub struct Provider;
@@ -73,7 +75,6 @@ pub const TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
             hash_provider: hash::SHA256,
             confidentiality_limit: u64::MAX,
-            integrity_limit: 1 << 36,
         },
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: &TLS12_ECDSA_SCHEMES,
@@ -88,7 +89,6 @@ pub const TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
             hash_provider: hash::SHA384,
             confidentiality_limit: u64::MAX,
-            integrity_limit: 1 << 36,
         },
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: &TLS12_ECDSA_SCHEMES,
@@ -103,7 +103,6 @@ pub const TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
             hash_provider: hash::SHA256,
             confidentiality_limit: u64::MAX,
-            integrity_limit: 1 << 36,
         },
         prf_provider: &rustls::crypto::tls12::PrfUsingHmac(hmac::SHA256),
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
@@ -125,7 +124,6 @@ pub const TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
             hash_provider: hash::SHA256,
             confidentiality_limit: u64::MAX,
-            integrity_limit: 1 << 36,
         },
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: &TLS12_RSA_SCHEMES,
@@ -140,7 +138,6 @@ pub const TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
             hash_provider: hash::SHA384,
             confidentiality_limit: u64::MAX,
-            integrity_limit: 1 << 36,
         },
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: &TLS12_RSA_SCHEMES,
@@ -155,7 +152,6 @@ pub const TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
             hash_provider: hash::SHA256,
             confidentiality_limit: u64::MAX,
-            integrity_limit: 1 << 36,
         },
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: &TLS12_RSA_SCHEMES,
@@ -186,7 +182,6 @@ pub const TLS13_AES_128_GCM_SHA256: SupportedCipherSuite =
             suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
             hash_provider: hash::SHA256,
             confidentiality_limit: u64::MAX,
-            integrity_limit: 1 << 36,
         },
         hkdf_provider: &rustls::crypto::tls13::HkdfUsingHmac(hmac::SHA256),
         aead_alg: &aead::gcm::Tls13Aes128Gcm,
@@ -199,7 +194,6 @@ pub const TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
             suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
             hash_provider: hash::SHA384,
             confidentiality_limit: u64::MAX,
-            integrity_limit: 1 << 36,
         },
         hkdf_provider: &rustls::crypto::tls13::HkdfUsingHmac(hmac::SHA384),
         aead_alg: &aead::gcm::Tls13Aes256Gcm,
@@ -215,7 +209,6 @@ pub const TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             suite: CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
             hash_provider: hash::SHA256,
             confidentiality_limit: u64::MAX,
-            integrity_limit: 1 << 36,
         },
         hkdf_provider: &rustls::crypto::tls13::HkdfUsingHmac(hmac::SHA256),
         aead_alg: &aead::chacha20::Chacha20Poly1305,

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -1,17 +1,13 @@
 #![allow(clippy::duplicate_mod)]
 
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 
 use aead::AeadCore;
 use chacha20poly1305::{AeadInPlace, KeyInit, KeySizeUser};
 use crypto_common::typenum::Unsigned;
-use rustls::{
-    crypto::{
-        cipher,
-        cipher::{AeadKey, Iv},
-    },
-    quic, Error, Tls13CipherSuite,
-};
+use rustls::crypto::cipher::{self, AeadKey, Iv};
+use rustls::{quic, Error, Tls13CipherSuite};
 
 pub struct HeaderProtectionKey(AeadKey);
 
@@ -115,6 +111,14 @@ impl quic::PacketKey for PacketKey {
     #[inline]
     fn tag_len(&self) -> usize {
         <chacha20poly1305::ChaCha20Poly1305 as AeadCore>::TagSize::to_usize()
+    }
+
+    fn integrity_limit(&self) -> u64 {
+        1 << 36
+    }
+
+    fn confidentiality_limit(&self) -> u64 {
+        u64::MAX
     }
 }
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,18 +1,16 @@
-use alloc::{sync::Arc, vec::Vec};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use pki_types::PrivateKeyDer;
-use rustls::{
-    sign::{Signer, SigningKey},
-    Error, SignatureScheme,
-};
-use signature::{RandomizedSigner, SignatureEncoding};
+use self::ecdsa::{EcdsaSigningKeyP256, EcdsaSigningKeyP384};
+use self::eddsa::Ed25519SigningKey;
+use self::rsa::RsaSigningKey;
 
-use self::{
-    ecdsa::{EcdsaSigningKeyP256, EcdsaSigningKeyP384},
-    eddsa::Ed25519SigningKey,
-    rsa::RsaSigningKey,
-};
+use pki_types::PrivateKeyDer;
+use rustls::sign::{Signer, SigningKey};
+use rustls::{Error, SignatureScheme};
+use signature::{RandomizedSigner, SignatureEncoding};
 
 #[derive(Debug)]
 pub struct GenericRandomizedSigner<S, T>

--- a/src/sign/ecdsa.rs
+++ b/src/sign/ecdsa.rs
@@ -1,10 +1,14 @@
-use alloc::{boxed::Box, format, sync::Arc};
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::sync::Arc;
 use core::marker::PhantomData;
 
 use paste::paste;
 use pkcs8::DecodePrivateKey;
 use pki_types::PrivateKeyDer;
-use rustls::{sign::SigningKey, SignatureAlgorithm, SignatureScheme};
+use rustls::sign::SigningKey;
+use rustls::{SignatureAlgorithm, SignatureScheme};
 use sec1::DecodeEcPrivateKey;
 
 macro_rules! impl_ecdsa {

--- a/src/sign/eddsa.rs
+++ b/src/sign/eddsa.rs
@@ -1,12 +1,13 @@
-use alloc::{boxed::Box, sync::Arc};
+use alloc::format;
+use alloc::sync::Arc;
 use core::marker::PhantomData;
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::string::ToString};
 
 use pkcs8::DecodePrivateKey;
 use pki_types::PrivateKeyDer;
-use rustls::{
-    sign::{Signer, SigningKey},
-    SignatureAlgorithm, SignatureScheme,
-};
+use rustls::sign::{Signer, SigningKey};
+use rustls::{SignatureAlgorithm, SignatureScheme};
 use sec1::DecodeEcPrivateKey;
 
 #[derive(Debug)]

--- a/src/sign/rsa.rs
+++ b/src/sign/rsa.rs
@@ -1,12 +1,14 @@
-use alloc::{boxed::Box, sync::Arc};
+use alloc::format;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use {alloc::boxed::Box, alloc::string::ToString};
 
-use pkcs8::{self, DecodePrivateKey};
+use pkcs8::DecodePrivateKey;
 use pki_types::PrivateKeyDer;
-use rsa::{pkcs1::DecodeRsaPrivateKey, RsaPrivateKey};
-use rustls::{
-    sign::{Signer, SigningKey},
-    SignatureAlgorithm, SignatureScheme,
-};
+use rsa::pkcs1::DecodeRsaPrivateKey;
+use rsa::RsaPrivateKey;
+use rustls::sign::{Signer, SigningKey};
+use rustls::{SignatureAlgorithm, SignatureScheme};
 use sha2::{Sha256, Sha384, Sha512};
 
 const ALL_RSA_SCHEMES: &[SignatureScheme] = &[

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,12 +1,11 @@
-use rustls::{crypto::WebPkiSupportedAlgorithms, SignatureScheme};
+use rustls::crypto::WebPkiSupportedAlgorithms;
+use rustls::SignatureScheme;
 
-use self::{
-    ecdsa::{ECDSA_P256_SHA256, ECDSA_P256_SHA384, ECDSA_P384_SHA256, ECDSA_P384_SHA384},
-    eddsa::ED25519,
-    rsa::{
-        RSA_PKCS1_SHA256, RSA_PKCS1_SHA384, RSA_PKCS1_SHA512, RSA_PSS_SHA256, RSA_PSS_SHA384,
-        RSA_PSS_SHA512,
-    },
+use self::ecdsa::{ECDSA_P256_SHA256, ECDSA_P256_SHA384, ECDSA_P384_SHA256, ECDSA_P384_SHA384};
+use self::eddsa::ED25519;
+use self::rsa::{
+    RSA_PKCS1_SHA256, RSA_PKCS1_SHA384, RSA_PKCS1_SHA512, RSA_PSS_SHA256, RSA_PSS_SHA384,
+    RSA_PSS_SHA512,
 };
 
 pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {

--- a/src/verify/rsa.rs
+++ b/src/verify/rsa.rs
@@ -1,6 +1,7 @@
 use paste::paste;
 use pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
-use rsa::{pkcs1::DecodeRsaPublicKey, pkcs1v15, pss, RsaPublicKey};
+use rsa::pkcs1::DecodeRsaPublicKey;
+use rsa::{pkcs1v15, pss, RsaPublicKey};
 use sha2::{Sha256, Sha384, Sha512};
 use signature::Verifier;
 use webpki::alg_id;


### PR DESCRIPTION
Until upstream hyper-rustls and tokio-rustls are upgraded correspondingly, tests won't work atm.

Related: https://github.com/rustls/hyper-rustls/pull/256, https://github.com/rustls/tokio-rustls/pull/44