### PR TITLE
Add consumer validation for no_std

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -1,0 +1,15 @@
+# rustls-rustcrypto Validation
+
+These are collection of crates that can be used to validate integration
+between rustls and rustcrypto-rustcrypto provider under different targets.
+
+| Crate            | Description                                      |
+| :---             | :---                                             |
+| consumer-no_std  | Basic consumer library aiming no_std environment |
+
+These live in the workspace due to different dependency requirements between
+tests where development-deps may pollute the integration under test.
+
+This is aimed for internal validation without requiring further upstream
+dependencies which are may or may not be in lock-step with current version of
+rustls the provider targets in any given time.

--- a/validation/consumer-no_std/Cargo.toml
+++ b/validation/consumer-no_std/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "consumer-no_std"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.orxg/cargo/reference/manifest.html
+
+[dependencies]
+rustls-rustcrypto = { path = "../../" }
+rustls = { version = "0.23", default-features = false }

--- a/validation/consumer-no_std/README.md
+++ b/validation/consumer-no_std/README.md
@@ -1,0 +1,3 @@
+# no_std Consumer build
+
+Simple self-tester to validate no_std build with a given rustls version.

--- a/validation/consumer-no_std/src/fakes.rs
+++ b/validation/consumer-no_std/src/fakes.rs
@@ -1,0 +1,2 @@
+pub(crate) mod fake_cert_verifier;
+pub(crate) mod fake_time_provider;

--- a/validation/consumer-no_std/src/fakes/fake_cert_verifier.rs
+++ b/validation/consumer-no_std/src/fakes/fake_cert_verifier.rs
@@ -1,0 +1,61 @@
+use rustls::client::danger::HandshakeSignatureValid;
+use rustls::client::danger::ServerCertVerified;
+use rustls::client::danger::ServerCertVerifier;
+use rustls::pki_types::CertificateDer;
+use rustls::pki_types::ServerName;
+use rustls::pki_types::UnixTime;
+use rustls::DigitallySignedStruct;
+use rustls::Error;
+use rustls::SignatureScheme;
+
+use alloc::vec::Vec;
+
+#[derive(Debug)]
+pub(crate) struct FakeServerCertVerifier;
+
+impl ServerCertVerifier for FakeServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        alloc::vec![
+            SignatureScheme::RSA_PKCS1_SHA1,
+            SignatureScheme::ECDSA_SHA1_Legacy,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+            SignatureScheme::ED448,
+            //SignatureScheme::Unknown(u16),
+        ]
+    }
+}

--- a/validation/consumer-no_std/src/fakes/fake_time_provider.rs
+++ b/validation/consumer-no_std/src/fakes/fake_time_provider.rs
@@ -1,0 +1,14 @@
+use rustls::time_provider::TimeProvider;
+//use core::time::Duration;
+use rustls::pki_types::UnixTime;
+
+// Required for no_std
+#[derive(Debug)]
+pub(crate) struct FakeTime;
+
+// TODO: Figure how to handle time
+impl TimeProvider for FakeTime {
+    fn current_time(&self) -> Option<UnixTime> {
+        None
+    }
+}

--- a/validation/consumer-no_std/src/lib.rs
+++ b/validation/consumer-no_std/src/lib.rs
@@ -1,0 +1,62 @@
+#![no_std]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::unwrap_used,
+    //missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
+#![doc = include_str!("../README.md")]
+#![allow(dead_code)] // HEAVY TODO
+
+//! RusTLS RustCrypto ValidationProvider
+//! This crate is used to internally minimally validate the provider in CI
+//! Obviously - don't use in prod ;-)
+
+// I hope in future there is an API without Arc for providers
+extern crate alloc;
+use alloc::sync::Arc;
+
+use rustls::client::ClientConfig as RusTlsClientConfig;
+
+use rustls_rustcrypto::provider as rustcrypto_provider;
+
+// TODO: rustcrypto tls PKI verifier provider missing
+// We are not testing webpki / rustls itself which typically handle certificates
+// Perhaps a separate crate for PKI operations e.g. cert verifying and then test that ?
+mod fakes;
+use crate::fakes::fake_cert_verifier::FakeServerCertVerifier;
+use crate::fakes::fake_time_provider::FakeTime;
+
+pub struct ProviderValidatorClient {
+    pub(crate) rustls_client_config: RusTlsClientConfig,
+}
+
+impl ProviderValidatorClient {
+    pub fn builder() -> Self {
+        let provider = rustcrypto_provider();
+        let time_provider = FakeTime {};
+
+        let fake_server_cert_verifier = FakeServerCertVerifier {};
+
+        let builder_init =
+            RusTlsClientConfig::builder_with_details(Arc::new(provider), Arc::new(time_provider));
+
+        let builder_default_versions = builder_init
+            .with_safe_default_protocol_versions()
+            .expect("Default protocol versions error?");
+
+        // TODO - test with different verifiers
+        let dangerous_verifier = builder_default_versions
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(fake_server_cert_verifier));
+
+        // Out of scope
+        let rustls_client_config = dangerous_verifier.with_no_client_auth();
+
+        Self {
+            rustls_client_config,
+        }
+    }
+}


### PR DESCRIPTION
Note the crate itself compiles currently in std as we don't have test for no_std

But having the scenario we can build-test the integration properly without polluting via dependencies

I'm wondering if I could / should move this into as an integration test but then I can't isolate this as self-contained crate

The benefit of having self-contained crate is that it's more readable what is exactly being validated vs going through a lot of gating and feature-dependencies within integration tests attached to the main provider crate ? I'm wrong maybe ?