### PR TITLE
Address dead_code lint for quic todo part

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2",
  "subtle",
  "zeroize",
@@ -739,6 +740,26 @@ name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+
+[[package]]
+name = "serde"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sha2"

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -9,6 +9,7 @@ use crypto_common::typenum::Unsigned;
 use rustls::crypto::cipher::{self, AeadKey, Iv};
 use rustls::{quic, Error, Tls13CipherSuite};
 
+#[allow(dead_code)] // TODO
 pub struct HeaderProtectionKey(AeadKey);
 
 impl HeaderProtectionKey {
@@ -122,6 +123,7 @@ impl quic::PacketKey for PacketKey {
     }
 }
 
+#[allow(dead_code)] // TODO
 pub struct KeyBuilder(AeadKey);
 
 impl rustls::quic::Algorithm for KeyBuilder {


### PR DESCRIPTION
These bits are todo so it is best to just allow temporarily dead_code here