### PR TITLE
Improve rustdoc and attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,22 @@
-#![deny(
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+)]
+#![warn(
     clippy::all,
     // TODO: clippy::pedantic,
     clippy::alloc_instead_of_core,
     clippy::std_instead_of_alloc,
     clippy::std_instead_of_core
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+
+//! # Usage
+//!
+//! See [`examples-xsmall`](https://github.com/RustCrypto/rustls-rustcrypto/tree/master/examples-xsmall)
+//! for a usage example.
 
 #[cfg(not(feature = "alloc"))]
 compile_error!("Rustls currently does not support alloc-less environments");


### PR DESCRIPTION
- Imports README.md into the rustdoc, which previously lacked any sort of warnings about the state of the code
- Use `no_std` unconditionally, which Just Works. We can link `std` separately if actually needed.
- Use `warn` instead of `deny`: we deny warnings in CI anyway
- Add logo to generated rustdoc
- Enable `doc_auto_cfg` on docs.rs