### PR TITLE
CI: run `cargo doc` with `--no-deps`

### DIFF
--- a/.github/workflows/rustls-rustcrypto.yml
+++ b/.github/workflows/rustls-rustcrypto.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - run: cargo doc --all-features
+      - run: cargo doc --all-features --no-deps
 
   rustfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We only care that `rustls-rustcrypto` documentation builds successfully, so avoid documenting dependencies to improve build times