### PR TITLE
feat: enable SHA-224/SHA-512 hash providers and SHA-512 HMAC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -220,7 +220,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "subtle",
  "typenum",
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "log"
@@ -548,18 +548,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -711,31 +711,31 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -796,6 +796,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -4,7 +4,7 @@ use alloc::boxed::Box;
 use digest::{Digest, OutputSizeUser};
 use paste::paste;
 use rustls::crypto::{self, hash};
-use sha2::{Sha256, Sha384};
+use sha2::{Sha224, Sha256, Sha384, Sha512};
 
 macro_rules! impl_hash {
     ($name:ident, $ty:ty, $algo:ty) => {
@@ -56,7 +56,23 @@ macro_rules! impl_hash {
     };
 }
 
-// impl_hash! {SHA224, Sha224, hash::HashAlgorithm::SHA224}
+impl_hash! {SHA224, Sha224, hash::HashAlgorithm::SHA224}
 impl_hash! {SHA256, Sha256, hash::HashAlgorithm::SHA256}
 impl_hash! {SHA384, Sha384, hash::HashAlgorithm::SHA384}
-// impl_hash! {SHA512, Sha512, hash::HashAlgorithm::SHA512}
+impl_hash! {SHA512, Sha512, hash::HashAlgorithm::SHA512}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha224_and_sha512_providers() {
+        assert_eq!(SHA224.output_len(), 28);
+        assert_eq!(SHA224.algorithm(), hash::HashAlgorithm::SHA224);
+        assert_eq!(SHA224.hash(b"abc").as_ref().len(), 28);
+
+        assert_eq!(SHA512.output_len(), 64);
+        assert_eq!(SHA512.algorithm(), hash::HashAlgorithm::SHA512);
+        assert_eq!(SHA512.hash(b"abc").as_ref().len(), 64);
+    }
+}

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -5,7 +5,7 @@ use crypto_common::OutputSizeUser;
 use hmac::{KeyInit, Mac};
 use paste::paste;
 use rustls::crypto;
-use sha2::{Sha256, Sha384};
+use sha2::{Sha256, Sha384, Sha512};
 
 macro_rules! impl_hmac {
     (
@@ -53,4 +53,18 @@ macro_rules! impl_hmac {
 
 impl_hmac! {SHA256, Sha256}
 impl_hmac! {SHA384, Sha384}
-// impl_hmac! {SHA512, Sha512}
+impl_hmac! {SHA512, Sha512}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha512_hmac_provider() {
+        assert_eq!(SHA512.hash_output_len(), 64);
+        let key = SHA512.with_key(b"key");
+        assert_eq!(key.tag_len(), 64);
+        let tag = key.sign_concat(b"a", &[], b"b");
+        assert_eq!(tag.as_ref().len(), 64);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,8 +261,10 @@ static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = misc::const_concat_slices!(
 );
 
 mod aead;
-mod hash;
-mod hmac;
+/// Hash algorithm providers (SHA-224/256/384/512).
+pub mod hash;
+/// HMAC providers (SHA-256/384/512).
+pub mod hmac;
 mod kx;
 mod misc;
 pub mod quic;


### PR DESCRIPTION
## Summary

Independent of the feature stack (#287–#291). Based on `master`.

- Enable **SHA-224** and **SHA-512** hash algorithm providers (previously commented out)
- Enable **SHA-512** HMAC
- Make `hash` / `hmac` modules **public** for custom `CryptoProvider` construction
- Unit tests for the new providers

## Test plan

- [x] `cargo test --lib` (hash/hmac provider tests)
- [ ] CI green

## Notes

This does **not** depend on the QUIC / curves / CCM / ticketer stack. It can land on master on its own.